### PR TITLE
remove img-responsive from emoji

### DIFF
--- a/coffee/parseEmoji.coffee
+++ b/coffee/parseEmoji.coffee
@@ -3,7 +3,7 @@
     mappingEnabled = settings.get 'mapping.enabled'
     content.replace replaceRegex, (match) ->
       emoji.parse (if mappingEnabled then execMapping(match) else match), emojiPath,
-        classes: 'emoji emoji-extended img-responsive'
+        classes: 'emoji emoji-extended'
         attributes:
           title: (match, name, parameter) -> if parameter? then parameter else name
           alt: (match, name, parameter) -> if parameter? then parameter else match


### PR DESCRIPTION
We actually purposely don't add img-responsive to emoji in core:

https://github.com/NodeBB/NodeBB/blob/master/public/src/client/topic/posts.js#L256

You probably won't need it either since emoji's are just 20px wide